### PR TITLE
Maintain timestep and goal-based rewards

### DIFF
--- a/manual_control.py
+++ b/manual_control.py
@@ -1,0 +1,53 @@
+import time
+import numpy as np
+import pybullet as p
+from backhoe_env import BackhoeHydraulicEnv
+
+
+def main():
+    env = BackhoeHydraulicEnv(render=True)
+    obs, _ = env.reset()
+
+    print("\nSteuerung mit Pfeiltasten:")
+    print("  \u2191 / \u2193   = Boom hoch / runter")
+    print("  \u2190 / \u2192   = Stick raus / rein")
+    print("  Pos1 / Ende = Turret links / rechts")
+    print("  Bild\u2191 / Bild\u2193 = Bucket auf / zu")
+    print("STRG+C zum Abbrechen.\n")
+
+    try:
+        while True:
+            keys = p.getKeyboardEvents()
+            action = np.zeros(env.action_space.shape, dtype=np.float32)
+            step = 0.8  # Schrittweite (zwischen -1.0 und 1.0)
+
+            if p.B3G_UP_ARROW in keys and keys[p.B3G_UP_ARROW] & p.KEY_IS_DOWN:
+                action[1] = +step
+            elif p.B3G_DOWN_ARROW in keys and keys[p.B3G_DOWN_ARROW] & p.KEY_IS_DOWN:
+                action[1] = -step
+
+            if p.B3G_LEFT_ARROW in keys and keys[p.B3G_LEFT_ARROW] & p.KEY_IS_DOWN:
+                action[2] = +step
+            elif p.B3G_RIGHT_ARROW in keys and keys[p.B3G_RIGHT_ARROW] & p.KEY_IS_DOWN:
+                action[2] = -step
+
+            if p.B3G_HOME in keys and keys[p.B3G_HOME] & p.KEY_IS_DOWN:
+                action[0] = +step
+            elif p.B3G_END in keys and keys[p.B3G_END] & p.KEY_IS_DOWN:
+                action[0] = -step
+
+            if p.B3G_PAGE_UP in keys and keys[p.B3G_PAGE_UP] & p.KEY_IS_DOWN:
+                action[3] = +step
+            elif p.B3G_PAGE_DOWN in keys and keys[p.B3G_PAGE_DOWN] & p.KEY_IS_DOWN:
+                action[3] = -step
+
+            env.step(action)
+            time.sleep(env.time_step)
+    except KeyboardInterrupt:
+        print("Manuelle Steuerung beendet.")
+
+    env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/real_backhoe.urdf
+++ b/real_backhoe.urdf
@@ -1,105 +1,156 @@
 <?xml version="1.0"?>
-<robot name="real_backhoe">
-  <link name="base" />
+<robot name="backhoe_ZX55UR-5B">
 
-  <!-- Turret -->
+  <!-- 1. Turret -->
   <link name="turret">
     <inertial>
-      <mass value="500" />
-      <inertia ixx="100" iyy="100" izz="100" />
+      <origin xyz="0 0 0.1"/>
+      <mass value="3000.0"/>
+      <inertia ixx="5" iyy="5" izz="5" ixy="0" ixz="0" iyz="0"/>
     </inertial>
     <visual>
-      <geometry><box size="0.8 0.8 0.4"/></geometry>
-      <origin xyz="0 0 0.2"/>
-      <material name="yellow"><color rgba="0.9 0.8 0.1 1"/></material>
+      <geometry>
+        <box size="1.6 1.6 0.2"/>
+      </geometry>
+      <origin xyz="0 0 0.1"/>
+      <material name="red">
+        <color rgba="1 0 0 1"/>
+      </material>
     </visual>
+    <collision>
+      <geometry>
+        <box size="1.6 1.6 0.2"/>
+      </geometry>
+      <origin xyz="0 0 0.1"/>
+    </collision>
   </link>
-  <joint name="turret_joint" type="revolute">
-    <parent link="base"/>
-    <child link="turret"/>
-    <origin xyz="0 0 0" rpy="0 0 0"/>
-    <axis xyz="0 0 1"/>
-    <limit effort="1200" lower="-3.14" upper="3.14" velocity="1.2"/>
-  </joint>
 
-  <!-- Boom -->
-  <link name="boom">
+  <!-- 2.1 Boom Segment 1 (vertikal) -->
+  <link name="boom_lower">
     <inertial>
-      <mass value="700" />
-      <inertia ixx="150" iyy="150" izz="30" />
+      <origin xyz="0 0 0.9"/>
+      <mass value="200"/>
+      <inertia ixx="2" iyy="2" izz="1" ixy="0" ixz="0" iyz="0"/>
     </inertial>
     <visual>
-      <geometry><box size="0.4 0.4 3"/></geometry>
-      <origin xyz="0 0 1.5"/>
-      <material name="yellow"/>
+      <geometry>
+        <box size="0.5 0.5 1.8"/>
+      </geometry>
+      <origin xyz="0 0 0.9"/>
+      <material name="blue">
+        <color rgba="0 0 1 1"/>
+      </material>
     </visual>
+    <collision>
+      <geometry>
+        <box size="0.5 0.5 1.8"/>
+      </geometry>
+      <origin xyz="0 0 0.9"/>
+    </collision>
   </link>
-  <joint name="boom_joint" type="revolute">
+
+  <!-- 2.2 Boom Segment 2 (leicht nach vorne geneigt) -->
+  <link name="boom_upper">
+    <inertial>
+      <origin xyz="0 0 0.9"/>
+      <mass value="182"/>
+      <inertia ixx="1" iyy="1" izz="0.5" ixy="0" ixz="0" iyz="0"/>
+    </inertial>
+    <visual>
+      <geometry>
+        <box size="0.4 0.4 1.8"/>
+      </geometry>
+      <origin xyz="0.5 0.0 0.9" rpy="0.0 0.4 0.0"/>
+      <material name="blue">
+        <color rgba="0 0 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <geometry>
+        <box size="0.5 0.5 1.8"/>
+      </geometry>
+      <origin xyz="0 0 0.9" rpy="0 0 0.3"/>
+    </collision>
+  </link>
+
+  <!-- Boom-Teil 1 wird am Turret montiert -->
+  <joint name="turret_to_boom_lower" type="revolute">
     <parent link="turret"/>
-    <child link="boom"/>
-    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <child link="boom_lower"/>
+    <origin xyz="0 0 0.5" rpy="0 0 0"/>
     <axis xyz="0 1 0"/>
-    <limit effort="1200" lower="-0.2" upper="1.1" velocity="1.2"/>
+    <limit lower="-0.4" upper="1.2" effort="1000" velocity="1.5"/>
   </joint>
 
-  <!-- Stick -->
+  <!-- Boom-Teil 2 ist fest mit Teil 1 verbunden -->
+  <joint name="boom_fixed_joint" type="fixed">
+    <parent link="boom_lower"/>
+    <child link="boom_upper"/>
+    <origin xyz="0 0 1.8" rpy="0 0 0"/>
+  </joint>
+
+  <!-- 3. Stick -->
   <link name="stick">
     <inertial>
-      <mass value="400" />
-      <inertia ixx="80" iyy="80" izz="20" />
+      <origin xyz="0 0 0.8"/>
+      <mass value="156.0"/>
+      <inertia ixx="2" iyy="2" izz="0.8" ixy="0" ixz="0" iyz="0"/>
     </inertial>
     <visual>
-      <geometry><box size="0.3 0.3 2.5"/></geometry>
-      <origin xyz="0 0 1.25"/>
-      <material name="yellow"/>
+      <geometry>
+        <box size="0.3 0.3 1.6"/>
+      </geometry>
+      <origin xyz="0 0 0.8"/>
+      <material name="yellow">
+        <color rgba="1 1 0 1"/>
+      </material>
     </visual>
+    <collision>
+      <geometry>
+        <box size="0.3 0.3 1.6"/>
+      </geometry>
+      <origin xyz="0 0 0.8"/>
+    </collision>
   </link>
-  <joint name="stick_joint" type="revolute">
-    <parent link="boom"/>
+
+  <joint name="boom_to_stick" type="revolute">
+    <parent link="boom_upper"/>
     <child link="stick"/>
-    <origin xyz="0 0 3" rpy="0 0 0"/>
+    <origin xyz="0 0 1.8" rpy="0 0 0"/>
     <axis xyz="0 1 0"/>
-    <limit effort="800" lower="-0.1" upper="2.4" velocity="1.2"/>
+    <limit lower="-1.57" upper="1.57" effort="800" velocity="3.2"/>
   </joint>
 
-  <!-- Bucket cylinder (prismatic) -->
-  <link name="bucket_cylinder">
-    <inertial>
-      <mass value="100" />
-      <inertia ixx="5" iyy="5" izz="5" />
-    </inertial>
-    <visual>
-      <geometry><cylinder length="0.6" radius="0.05"/></geometry>
-      <origin xyz="0 0 0" rpy="1.5708 0 0"/>
-      <material name="silver"><color rgba="0.7 0.7 0.7 1"/></material>
-    </visual>
-  </link>
-  <joint name="bucket_cyl_joint" type="prismatic">
-    <parent link="stick"/>
-    <child link="bucket_cylinder"/>
-    <origin xyz="0 0 2.3" rpy="0 0 0"/>
-    <axis xyz="0 0 1"/>
-    <limit effort="500" lower="0.0" upper="0.5" velocity="0.5"/>
-  </joint>
-
-  <!-- Bucket -->
+  <!-- 4. Bucket -->
   <link name="bucket">
     <inertial>
-      <mass value="200" />
-      <inertia ixx="20" iyy="20" izz="10" />
+      <origin xyz="0 0 0.2"/>
+      <mass value="100.0"/>
+      <inertia ixx="1" iyy="1" izz="0.5" ixy="0" ixz="0" iyz="0"/>
     </inertial>
     <visual>
-      <geometry><box size="0.8 0.6 0.6"/></geometry>
-      <origin xyz="0 0 0.3"/>
-      <material name="yellow"/>
+      <geometry>
+        <box size="0.5 1.0 0.4"/>
+      </geometry>
+      <origin xyz="0 0 0.2"/>
+      <material name="green">
+        <color rgba="0 1 0 1"/>
+      </material>
     </visual>
+    <collision>
+      <geometry>
+        <box size="0.5 1.0 0.4"/>
+      </geometry>
+      <origin xyz="0 0 0.2"/>
+    </collision>
   </link>
-  <joint name="bucket_joint" type="revolute">
+
+  <joint name="stick_to_bucket" type="revolute">
     <parent link="stick"/>
     <child link="bucket"/>
-    <origin xyz="0 0 2.4" rpy="0 0 0"/>
+    <origin xyz="0 0 1.6" rpy="0 0 0"/>
     <axis xyz="0 1 0"/>
-    <limit effort="600" lower="-1.2" upper="0.6" velocity="1.5"/>
-    <mimic joint="bucket_cyl_joint" multiplier="-2.5"/>
+    <limit lower="-1.5" upper="1.5" effort="500" velocity="1.0"/>
   </joint>
+
 </robot>


### PR DESCRIPTION
## Summary
- Replace backhoe model with more detailed ZX55UR-5B URDF
- Compute hydraulic torques for all joints and keep custom physics timestep after resets
- Track goal posture for reward and provide keyboard teleoperation example

## Testing
- `python -m py_compile backhoe_env.py manual_control.py`
- `pip install gymnasium` *(fails: Could not connect to proxy)*
- `pip install numpy` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68962224a2b8832c86f0d3f49a42c91b